### PR TITLE
Feature: Iterate Matched Patterns.

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -14,14 +14,14 @@ namespace TestApp
 
                 Console.WriteLine($"Number of rules: {yara.RulesCount()}");
 
-                Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA);
-                scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
+                Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS);
                 scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
                 List<Rule> results = scanner.Results();
                 Console.WriteLine($"Matches: {results.Count}");
 
                 foreach (Rule rule in results)
                 {
+                    Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
                     Console.WriteLine(rule.Metadata["malware_family"]);
                 }
 

--- a/YaraXSharp/Rule.cs
+++ b/YaraXSharp/Rule.cs
@@ -11,6 +11,7 @@ namespace YaraXSharp
     {
         private delegate void YRX_METADATA_CALLBACK(IntPtr metadata);
         private delegate void YRX_TAGS_CALLBACK(IntPtr tag);
+        private delegate void YRX_PATTERN_CALLBACK(IntPtr pattern);
 
         [DllImport("yara_x_capi.dll")]
         private static extern IntPtr yrx_rule_iter_metadata(IntPtr rule, YRX_METADATA_CALLBACK callback);
@@ -18,14 +19,22 @@ namespace YaraXSharp
         [DllImport("yara_x_capi.dll")]
         private static extern IntPtr yrx_rule_iter_tags(IntPtr rule, YRX_TAGS_CALLBACK callback);
 
+        [DllImport("yara_x_capi.dll")]
+        private static extern IntPtr yrx_rule_iter_patterns(IntPtr rule, YRX_PATTERN_CALLBACK callback);
+
+        [DllImport("yara_x_capi.dll")]
+        private static extern YRX_RESULT yrx_pattern_identifier(IntPtr pattern, out IntPtr identifier, out int length);
+
         private IntPtr _rule;
         public Dictionary<string, object> Metadata = new Dictionary<string, object>();
         public List<string> Tags = new List<string>();
+        public List<string> Patterns = new List<string>();
         public Rule(IntPtr rule, params YRX_SCANNER_FLAGS[] load_info)
         {
             _rule = rule;
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_METADATA)) GetMetadata();
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_TAGS)) GetTags();
+            if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_PATTERNS)) GetPatterns();
         }
 
         private void GetMetadata()
@@ -36,6 +45,11 @@ namespace YaraXSharp
         private void GetTags()
         {
             yrx_rule_iter_tags(_rule, TagsCallback);
+        }
+
+        private void GetPatterns()
+        {
+            yrx_rule_iter_patterns(_rule, PatternsCallback);
         }
 
         private void MetadataCallback(IntPtr metadata)
@@ -67,6 +81,19 @@ namespace YaraXSharp
         private void TagsCallback(IntPtr tag)
         {
             Tags.Add(Marshal.PtrToStringUTF8(tag));
+        }
+
+        private void PatternsCallback(IntPtr pattern)
+        {
+            IntPtr identifier;
+            int length;
+            yrx_pattern_identifier(pattern, out identifier, out length);
+
+            if (length == 0) return;
+
+            byte[] buffer = new byte[length];
+            Marshal.Copy(identifier, buffer, 0, length);
+            Patterns.Add(Encoding.UTF8.GetString(buffer));
         }
     }
 }


### PR DESCRIPTION
You can now iterate through matched pattern in rules.
```csharp
List<Rule> results = scanner.Results();
foreach (Rule rule in results)
{
    foreach (string pattern in rule.Patterns) {
        Console.WriteLine(pattern);
    }
}
```