### PR TITLE
Feature: Errors and Warning

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -7,9 +7,20 @@ namespace TestApp
         {
             try
             {
-                var yara = new YaraX(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES);
+                var yara = new YaraX();
                 yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eicar.yar"));
                 yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eitwo.yar"));
+
+                // Error and warning checks have to come before Build.
+                var errors = yara.Errors();
+                if (errors.Length > 0)
+                {
+                    foreach (var error in errors)
+                    {
+                        Console.WriteLine(error.text);
+                    }
+                }
+
                 var rules = yara.Build();
 
                 Console.WriteLine($"Number of rules: {yara.RulesCount()}");
@@ -28,7 +39,8 @@ namespace TestApp
                 // Make sure to destroy.
                 scanner.Destroy();
                 yara.Destroy();
-            } catch (YrxException ex)
+            }
+            catch (YrxException ex)
             {
                 Console.Write(ex.Message);
             }

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -11,17 +11,10 @@ namespace TestApp
                 yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eicar.yar"));
                 yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eitwo.yar"));
 
-                // Error and warning checks have to come before Build.
-                var errors = yara.Errors();
-                if (errors.Length > 0)
-                {
-                    foreach (var error in errors)
-                    {
-                        Console.WriteLine(error.text);
-                    }
-                }
+                var (rules, errors, warnings) = yara.Build();
 
-                var rules = yara.Build();
+                if (errors.Length != 0) _LoopErrorFormat(errors);
+                if (warnings.Length != 0) _LoopErrorFormat(warnings);
 
                 Console.WriteLine($"Number of rules: {yara.RulesCount()}");
 
@@ -43,6 +36,14 @@ namespace TestApp
             catch (YrxException ex)
             {
                 Console.Write(ex.Message);
+            }
+        }
+
+        public static void _LoopErrorFormat(YrxErrorFormat[] errors)
+        {
+            foreach (var error in errors)
+            {
+                Console.WriteLine(error.text);
             }
         }
     }

--- a/YaraXSharp/Declaratives.cs
+++ b/YaraXSharp/Declaratives.cs
@@ -35,7 +35,7 @@ namespace YaraXSharp
     internal struct YRX_BUFFER
     {
         public IntPtr data;
-        public int length;
+        public nuint length;
     }
 
 

--- a/YaraXSharp/Declaratives.cs
+++ b/YaraXSharp/Declaratives.cs
@@ -35,7 +35,7 @@ namespace YaraXSharp
     internal struct YRX_BUFFER
     {
         public IntPtr data;
-        public long length;
+        public int length;
     }
 
 
@@ -81,6 +81,14 @@ namespace YaraXSharp
     public class YrxException : Exception
     {
         public YrxException(string message) : base(message) { }
+    }
+
+    public class YrxErrorFormat
+    {
+        public required string type { get; set; }
+        public required string code { get; set; }
+        public required string title { get; set; }
+        public required string text { get; set; }
     }
     internal class Declaratives
     {

--- a/YaraXSharp/YaraXSharp.cs
+++ b/YaraXSharp/YaraXSharp.cs
@@ -57,16 +57,10 @@ namespace YaraXSharp
             var result = yrx_compiler_add_source(_compiler, File.ReadAllText(filePath));
             // if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
-
-        /* public Rules Build()
-        {
-            _rules = yrx_compiler_build(_compiler);
-            return _rules;
-        } */
         public Tuple<IntPtr, YrxErrorFormat[], YrxErrorFormat[]> Build()
         {
-            var errors = _Errors();
-            var warnings = _Warnings();
+            YrxErrorFormat[] errors = _Errors();
+            YrxErrorFormat[] warnings = _Warnings();
 
             _rules = yrx_compiler_build(_compiler);
             return Tuple.Create(_rules, errors, warnings);

--- a/YaraXSharp/YaraXSharp.cs
+++ b/YaraXSharp/YaraXSharp.cs
@@ -106,12 +106,10 @@ namespace YaraXSharp
             byte[] buffer = new byte[(int)yrx_buffer.length];
             var data = yrx_buffer.data;
             Marshal.Copy(yrx_buffer.data, buffer, 0, (int)yrx_buffer.length);
-
-            Console.WriteLine(Marshal.PtrToStringUTF8(yrx_buffer.data, (int)yrx_buffer.length));
-            Console.WriteLine(BitConverter.ToString(buffer));
-            // Unpredictable behaviour
             try
             {
+                // Unpredictable behaviour
+                // https://github.com/jtpox/Yara-X-Sharp/commit/afc33cd67d78df1eb94d90a245936f2203dff17c#commitcomment-162014780
                 return JsonConvert.DeserializeObject<YrxErrorFormat[]>(Encoding.UTF8.GetString(buffer));
             } catch (JsonException ex)
             {

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -30,4 +30,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Adds Errors and Warnings to `YaraX.Build()` via a tuple.

Usage:
```csharp
var yara = new YaraX();
var (rules, errors, warnings) = yara.Build();
```
`errors` and `warnings` will be JSON objects [[example](https://virustotal.github.io/yara-x/docs/api/c/c-/#yrx_compiler_errors_json)] with [this structure](https://github.com/jtpox/Yara-X-Sharp/blob/010dd592c48625b638c005bd365af1626bc5d3b9/YaraXSharp/Declaratives.cs#L86).

Behavior can be inconsistent. [Link](https://github.com/jtpox/Yara-X-Sharp/commit/afc33cd67d78df1eb94d90a245936f2203dff17c#commitcomment-162014780) for more info.