### PR TITLE
1.0.0

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -22,6 +22,7 @@ namespace TestApp
 
                     using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))
                     {
+                        scanner.SetTimeout(3);
                         scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
                         List<Match> results = scanner.Results();
                         Console.WriteLine($"Matches: {results.Count}");

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -20,7 +20,13 @@ namespace TestApp
 
                     Console.WriteLine($"Number of rules: {rules.Count()}");
 
-                    using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))
+                    using (Scanner scanner = new Scanner(
+                        rules,
+                        YRX_SCANNER_FLAGS.LOAD_METADATA,
+                        YRX_SCANNER_FLAGS.LOAD_PATTERNS,
+                        YRX_SCANNER_FLAGS.LOAD_NAMESPACE,
+                        YRX_SCANNER_FLAGS.LOAD_IDENTIFIER
+                    ))
                     {
                         scanner.SetTimeout(3);
                         scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
@@ -30,7 +36,10 @@ namespace TestApp
                         foreach (Match rule in results)
                         {
                             Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
-                            Console.WriteLine(rule.Metadata["malware_family"]);
+                            Console.WriteLine($"Family: {rule.Metadata["malware_family"]}");
+                            Console.WriteLine($"Namespace: {rule.Namespace}");
+                            Console.WriteLine($"Identifier: {rule.Identifier}");
+                            Console.WriteLine("-");
                         }
                     }
                 }
@@ -65,8 +74,15 @@ namespace TestApp
                     rules.Import(serializedRules);
                     Console.WriteLine($"Number of rules: {rules.Count()}");
 
-                    using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))
+                    using (Scanner scanner = new Scanner(
+                        rules,
+                        YRX_SCANNER_FLAGS.LOAD_METADATA,
+                        YRX_SCANNER_FLAGS.LOAD_PATTERNS,
+                        YRX_SCANNER_FLAGS.LOAD_NAMESPACE,
+                        YRX_SCANNER_FLAGS.LOAD_IDENTIFIER
+                    ))
                     {
+                        scanner.SetTimeout(3);
                         scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
                         List<Match> results = scanner.Results();
                         Console.WriteLine($"Matches: {results.Count}");
@@ -74,7 +90,10 @@ namespace TestApp
                         foreach (Match rule in results)
                         {
                             Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
-                            Console.WriteLine(rule.Metadata["malware_family"]);
+                            Console.WriteLine($"Family: {rule.Metadata["malware_family"]}");
+                            Console.WriteLine($"Namespace: {rule.Namespace}");
+                            Console.WriteLine($"Identifier: {rule.Identifier}");
+                            Console.WriteLine("-");
                         }
                     }
                 }

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -7,7 +7,8 @@ namespace TestApp
         {
             try
             {
-                using (var yara = new YaraX(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
+
+                using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
                 {
                     yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eicar.yar"));
                     yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eitwo.yar"));
@@ -16,15 +17,15 @@ namespace TestApp
                     if (errors.Length != 0) _LoopErrorFormat(errors);
                     if (warnings.Length != 0) _LoopErrorFormat(warnings);
 
-                    Console.WriteLine($"Number of rules: {yara.RulesCount()}");
+                    Console.WriteLine($"Number of rules: {rules.Count()}");
 
                     using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))
                     {
                         scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
-                        List<Rule> results = scanner.Results();
+                        List<Match> results = scanner.Results();
                         Console.WriteLine($"Matches: {results.Count}");
 
-                        foreach (Rule rule in results)
+                        foreach (Match rule in results)
                         {
                             Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
                             Console.WriteLine(rule.Metadata["malware_family"]);

--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -8,6 +8,7 @@ namespace TestApp
             try
             {
 
+                Console.WriteLine("Test 1");
                 using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
                 {
                     yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eicar.yar"));
@@ -17,6 +18,50 @@ namespace TestApp
                     if (errors.Length != 0) _LoopErrorFormat(errors);
                     if (warnings.Length != 0) _LoopErrorFormat(warnings);
 
+                    Console.WriteLine($"Number of rules: {rules.Count()}");
+
+                    using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))
+                    {
+                        scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
+                        List<Match> results = scanner.Results();
+                        Console.WriteLine($"Matches: {results.Count}");
+
+                        foreach (Match rule in results)
+                        {
+                            Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
+                            Console.WriteLine(rule.Metadata["malware_family"]);
+                        }
+                    }
+                }
+
+                Console.WriteLine("---");
+
+                Console.WriteLine("Test 2");
+                if (File.Exists("./ydb.dat")) File.Delete("./ydb.dat");
+                using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
+                {
+                    yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eicar.yar"));
+                    yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eitwo.yar"));
+                    var (rules, errors, warnings) = yara.Build();
+
+                    if (errors.Length != 0) _LoopErrorFormat(errors);
+                    if (warnings.Length != 0) _LoopErrorFormat(warnings);
+
+                    var export = rules.Export();
+                    using (var fs = new FileStream("./ydb.dat", FileMode.Create, FileAccess.Write))
+                    {
+                        fs.Write(export, 0, export.Length);
+                        Console.WriteLine("Serialized rules exported to ydb.dat");
+                    }
+                }
+
+                Console.WriteLine("---");
+
+                Console.WriteLine("Test 3");
+                using (Rules rules = new Rules())
+                {
+                    var serializedRules = File.ReadAllBytes("./ydb.dat");
+                    rules.Import(serializedRules);
                     Console.WriteLine($"Number of rules: {rules.Count()}");
 
                     using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))

--- a/YaraXSharp/Compiler.cs
+++ b/YaraXSharp/Compiler.cs
@@ -4,91 +4,59 @@ using System.Text;
 
 namespace YaraXSharp
 {
-    public class YaraX : IDisposable
+    public class Compiler : IDisposable
     {
-        [DllImport("yara_x_capi.dll")]
-        private static extern YRX_RESULT yrx_compiler_create(int flags, out IntPtr compiler);
+        internal IntPtr _compiler = IntPtr.Zero;
+        internal Rules? _rules = null;
 
-        [DllImport("yara_x_capi.dll")]
-        private static extern void yrx_compiler_destroy(IntPtr compiler);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern IntPtr yrx_compiler_build(IntPtr compiler);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern YRX_RESULT yrx_compiler_add_source(IntPtr compiler, string src);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern YRX_RESULT yrx_compiler_errors_json(IntPtr compiler, out IntPtr buf);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern YRX_RESULT yrx_compiler_warnings_json(IntPtr compiler, out IntPtr buf);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern void yrx_rules_destroy(IntPtr rules);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern void yrx_buffer_destroy(IntPtr buffer);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern int yrx_rules_count(IntPtr rules);
-
-        private Compiler _compiler = IntPtr.Zero;
-        private Rules _rules = IntPtr.Zero;
-
-        public YaraX(params YRX_COMPILE_FLAGS[] flags)
+        public Compiler(params YRX_COMPILE_FLAGS[] flags)
         {
             int allFlags = 0;
             foreach (var flag in flags) allFlags += (int)flag;
 
-            var compiler = yrx_compiler_create(allFlags, out _compiler);
+            var compiler = YaraX.yrx_compiler_create(allFlags, out _compiler);
             if (compiler != YRX_RESULT.YRX_SUCCESS) throw new YrxException(compiler.ToString());
         }
 
         public void Destroy()
         {
-            if (_rules != IntPtr.Zero) yrx_rules_destroy(_rules);
-            if (_compiler != IntPtr.Zero) yrx_compiler_destroy(_compiler);
+            if (_rules != null) _rules.Destroy();
+            if (_compiler != IntPtr.Zero) YaraX.yrx_compiler_destroy(_compiler);
 
             _compiler = IntPtr.Zero;
-            _rules = IntPtr.Zero;
+            _rules = null;
         }
 
         public void AddRuleFile(string filePath)
         {
             if (!File.Exists(filePath)) throw new YrxException("Rule file does not exist.");
-            var result = yrx_compiler_add_source(_compiler, File.ReadAllText(filePath));
+            var result = YaraX.yrx_compiler_add_source(_compiler, File.ReadAllText(filePath));
             // if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
-        public Tuple<IntPtr, YrxErrorFormat[], YrxErrorFormat[]> Build()
+        public Tuple<Rules, YrxErrorFormat[], YrxErrorFormat[]> Build()
         {
             YrxErrorFormat[] errors = _Errors();
             YrxErrorFormat[] warnings = _Warnings();
 
-            _rules = yrx_compiler_build(_compiler);
+            IntPtr rules = YaraX.yrx_compiler_build(_compiler);
+            _rules = new Rules(rules);
             return Tuple.Create(_rules, errors, warnings);
         }
-
-        public int RulesCount()
-        {
-            return yrx_rules_count(_rules);
-        }
-        
         private YrxErrorFormat[] _Errors()
         {
             IntPtr yrx_buffer_pointer;
-            yrx_compiler_errors_json(_compiler, out yrx_buffer_pointer);
+            YaraX.yrx_compiler_errors_json(_compiler, out yrx_buffer_pointer);
             YRX_BUFFER yrx_buffer = Marshal.PtrToStructure<YRX_BUFFER>(yrx_buffer_pointer);
-            yrx_buffer_destroy(yrx_buffer_pointer);
+            YaraX.yrx_buffer_destroy(yrx_buffer_pointer);
             return _GetJsonFromBuffer(yrx_buffer);
         }
 
         private YrxErrorFormat[] _Warnings()
         {
             IntPtr yrx_buffer_pointer;
-            yrx_compiler_warnings_json(_compiler, out yrx_buffer_pointer);
+            YaraX.yrx_compiler_warnings_json(_compiler, out yrx_buffer_pointer);
             YRX_BUFFER yrx_buffer = Marshal.PtrToStructure<YRX_BUFFER>(yrx_buffer_pointer);
-            yrx_buffer_destroy(yrx_buffer_pointer);
+            YaraX.yrx_buffer_destroy(yrx_buffer_pointer);
             return _GetJsonFromBuffer(yrx_buffer);
 
         }

--- a/YaraXSharp/Compiler.cs
+++ b/YaraXSharp/Compiler.cs
@@ -30,7 +30,8 @@ namespace YaraXSharp
         public void AddRuleFile(string filePath)
         {
             if (!File.Exists(filePath)) throw new YrxException("Rule file does not exist.");
-            var result = YaraX.yrx_compiler_add_source(_compiler, File.ReadAllText(filePath));
+            // var result = YaraX.yrx_compiler_add_source(_compiler, File.ReadAllText(filePath));
+            YaraX.yrx_compiler_add_source_with_origin(_compiler, File.ReadAllText(filePath), filePath);
             // if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
         public Tuple<Rules, YrxErrorFormat[], YrxErrorFormat[]> Build()

--- a/YaraXSharp/Declaratives.cs
+++ b/YaraXSharp/Declaratives.cs
@@ -12,6 +12,8 @@ namespace YaraXSharp
         LOAD_METADATA,
         LOAD_TAGS,
         LOAD_PATTERNS,
+        LOAD_NAMESPACE,
+        LOAD_IDENTIFIER,
     }
 
     public class YrxException : Exception

--- a/YaraXSharp/Declaratives.cs
+++ b/YaraXSharp/Declaratives.cs
@@ -1,7 +1,4 @@
-﻿global using Rules = System.IntPtr;
-global using Compiler = System.IntPtr;
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -15,73 +12,6 @@ namespace YaraXSharp
         LOAD_METADATA,
         LOAD_TAGS,
         LOAD_PATTERNS,
-    }
-    public enum YRX_COMPILE_FLAGS
-    {
-        YRX_COLORIZE_ERRORS = 1,
-        YRX_RELAXED_RE_SYNTAX = 2,
-        YRX_ERROR_ON_SLOW_PATTERN = 4,
-        YRX_ERROR_ON_SLOW_LOOP = 8,
-        YRX_ENABLE_CONDITION_OPTIMIZATION = 16,
-        YRX_DISABLE_INCLUDES = 32,
-    }
-    internal enum YRX_RESULT
-    {
-        YRX_SUCCESS = 0,
-        YRX_SYNTAX_ERROR = 1,
-        YRX_VARIABLE_ERROR = 3,
-        YRX_SCAN_ERROR = 4,
-        YRX_SCAN_TIMEOUT = 5,
-        YRX_INVALID_ARGUMENT = 6,
-        YRX_INVALID_UTF8 = 7,
-        YRX_SERIALIZATION_ERROR = 8,
-        YRX_NO_METADATA = 9,
-    }
-
-    internal struct YRX_BUFFER
-    {
-        public IntPtr data;
-        public nuint length;
-    }
-
-
-    public struct YRX_METADATA_BYTES
-    {
-        public int length;
-        public IntPtr data;
-    }
-
-    public enum YRX_METADATA_VALUE_TYPE
-    {
-        YRX_I64,
-        YRX_F64,
-        YRX_BOOLEAN,
-        YRX_STRING,
-        YRX_BYTES,
-    }
-
-    // Magic for union types.
-    [StructLayout(LayoutKind.Explicit)]
-    public struct YRX_METADATA_VALUE
-    {
-        [FieldOffset(0)]
-        public Int64 i64;
-        [FieldOffset(0)]
-        public double f64;
-        [FieldOffset(0)]
-        public bool boolean;
-        [FieldOffset(0)]
-        public IntPtr String;
-        // public char[] String;
-        [FieldOffset(0)]
-        public YRX_METADATA_BYTES bytes;
-    }
-
-    public struct YRX_METADATA
-    {
-        public string identifier;
-        public YRX_METADATA_VALUE_TYPE value_type;
-        public YRX_METADATA_VALUE value;
     }
 
     public class YrxException : Exception

--- a/YaraXSharp/Match.cs
+++ b/YaraXSharp/Match.cs
@@ -14,12 +14,16 @@ namespace YaraXSharp
         public Dictionary<string, object> Metadata = new Dictionary<string, object>();
         public List<string> Tags = new List<string>();
         public List<string> Patterns = new List<string>();
+        public string Namespace = null;
+        public string Identifier = null;
         public Match(IntPtr rule, params YRX_SCANNER_FLAGS[] load_info)
         {
             _rule = rule;
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_METADATA)) GetMetadata();
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_TAGS)) GetTags();
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_PATTERNS)) GetPatterns();
+            if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_NAMESPACE)) GetNamespace();
+            if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_IDENTIFIER)) GetIdentifier();
         }
 
         private void GetMetadata()
@@ -35,6 +39,24 @@ namespace YaraXSharp
         private void GetPatterns()
         {
             YaraX.yrx_rule_iter_patterns(_rule, PatternsCallback);
+        }
+
+        private void GetNamespace()
+        {
+            IntPtr pointer;
+            int length;
+            YaraX.yrx_rule_namespace(_rule, out pointer, out length);
+            if (length == 0) return;
+            Namespace = Marshal.PtrToStringUTF8(pointer, length);
+        }
+
+        private void GetIdentifier()
+        {
+            IntPtr pointer;
+            int length;
+            YaraX.yrx_rule_identifier(_rule, out pointer, out length);
+            if (length == 0) return;
+            Identifier = Marshal.PtrToStringUTF8(pointer, length);
         }
 
         private void MetadataCallback(IntPtr metadata)

--- a/YaraXSharp/Match.cs
+++ b/YaraXSharp/Match.cs
@@ -7,29 +7,14 @@ using System.Threading.Tasks;
 
 namespace YaraXSharp
 {
-    public class Rule
+    public class Match
     {
-        private delegate void YRX_METADATA_CALLBACK(IntPtr metadata);
-        private delegate void YRX_TAGS_CALLBACK(IntPtr tag);
-        private delegate void YRX_PATTERN_CALLBACK(IntPtr pattern);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern IntPtr yrx_rule_iter_metadata(IntPtr rule, YRX_METADATA_CALLBACK callback);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern IntPtr yrx_rule_iter_tags(IntPtr rule, YRX_TAGS_CALLBACK callback);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern IntPtr yrx_rule_iter_patterns(IntPtr rule, YRX_PATTERN_CALLBACK callback);
-
-        [DllImport("yara_x_capi.dll")]
-        private static extern YRX_RESULT yrx_pattern_identifier(IntPtr pattern, out IntPtr identifier, out int length);
 
         private IntPtr _rule;
         public Dictionary<string, object> Metadata = new Dictionary<string, object>();
         public List<string> Tags = new List<string>();
         public List<string> Patterns = new List<string>();
-        public Rule(IntPtr rule, params YRX_SCANNER_FLAGS[] load_info)
+        public Match(IntPtr rule, params YRX_SCANNER_FLAGS[] load_info)
         {
             _rule = rule;
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_METADATA)) GetMetadata();
@@ -39,17 +24,17 @@ namespace YaraXSharp
 
         private void GetMetadata()
         {
-            yrx_rule_iter_metadata(_rule, MetadataCallback);
+            YaraX.yrx_rule_iter_metadata(_rule, MetadataCallback);
         }
 
         private void GetTags()
         {
-            yrx_rule_iter_tags(_rule, TagsCallback);
+            YaraX.yrx_rule_iter_tags(_rule, TagsCallback);
         }
 
         private void GetPatterns()
         {
-            yrx_rule_iter_patterns(_rule, PatternsCallback);
+            YaraX.yrx_rule_iter_patterns(_rule, PatternsCallback);
         }
 
         private void MetadataCallback(IntPtr metadata)
@@ -87,7 +72,7 @@ namespace YaraXSharp
         {
             IntPtr identifier;
             int length;
-            yrx_pattern_identifier(pattern, out identifier, out length);
+            YaraX.yrx_pattern_identifier(pattern, out identifier, out length);
 
             if (length == 0) return;
 

--- a/YaraXSharp/Rules.cs
+++ b/YaraXSharp/Rules.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YaraXSharp
+{
+    public class Rules : IDisposable
+    {
+        internal IntPtr _pointer;
+        public Rules(IntPtr rulesPtr)
+        {
+            _pointer = rulesPtr;
+        }
+
+        public int Count()
+        {
+            return YaraX.yrx_rules_count(_pointer);
+        }
+
+        public void Destroy()
+        {
+            if (_pointer != IntPtr.Zero) YaraX.yrx_rules_destroy(_pointer);
+            _pointer = IntPtr.Zero;
+        }
+
+        public void Dispose()
+        {
+            Destroy();
+        }
+    }
+}

--- a/YaraXSharp/Rules.cs
+++ b/YaraXSharp/Rules.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -8,8 +9,8 @@ namespace YaraXSharp
 {
     public class Rules : IDisposable
     {
-        internal IntPtr _pointer;
-        public Rules(IntPtr rulesPtr)
+        internal IntPtr _pointer = IntPtr.Zero;
+        public Rules(IntPtr rulesPtr = default)
         {
             _pointer = rulesPtr;
         }
@@ -17,6 +18,28 @@ namespace YaraXSharp
         public int Count()
         {
             return YaraX.yrx_rules_count(_pointer);
+        }
+
+        public void Import(byte[] buffer)
+        {
+            if (buffer.Length == 0) throw new YrxException("Import buffer length is 0.");
+            YRX_RESULT result = YaraX.yrx_rules_deserialize(buffer, buffer.LongLength, out _pointer);
+            if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
+        }
+
+        public byte[] Export()
+        {
+            IntPtr yrx_buffer_pointer;
+            YRX_RESULT result = YaraX.yrx_rules_serialize(_pointer, out yrx_buffer_pointer);
+            if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
+
+            YRX_BUFFER yrx_buffer = Marshal.PtrToStructure<YRX_BUFFER>(yrx_buffer_pointer);
+
+            byte[] buffer = new byte[(int)yrx_buffer.length];
+            Marshal.Copy(yrx_buffer.data, buffer, 0, buffer.Length);
+            YaraX.yrx_buffer_destroy(yrx_buffer_pointer);
+
+            return buffer;
         }
 
         public void Destroy()

--- a/YaraXSharp/Scanner.cs
+++ b/YaraXSharp/Scanner.cs
@@ -24,6 +24,12 @@ namespace YaraXSharp
             YaraX.yrx_scanner_on_matching_rule(_scanner, OnMatchCallback);
         }
 
+        public void SetTimeout(int seconds)
+        {
+            YRX_RESULT result = YaraX.yrx_scanner_set_timeout(_scanner, seconds);
+            if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
+        }
+
         public void Scan(string filePath)
         {
             if (!File.Exists(filePath)) throw new YrxException("File does not exist.");

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace YaraXSharp
+{
+    public enum YRX_COMPILE_FLAGS
+    {
+        YRX_COLORIZE_ERRORS = 1,
+        YRX_RELAXED_RE_SYNTAX = 2,
+        YRX_ERROR_ON_SLOW_PATTERN = 4,
+        YRX_ERROR_ON_SLOW_LOOP = 8,
+        YRX_ENABLE_CONDITION_OPTIMIZATION = 16,
+        YRX_DISABLE_INCLUDES = 32,
+    }
+
+    public enum YRX_RESULT
+    {
+        YRX_SUCCESS = 0,
+        YRX_SYNTAX_ERROR = 1,
+        YRX_VARIABLE_ERROR = 3,
+        YRX_SCAN_ERROR = 4,
+        YRX_SCAN_TIMEOUT = 5,
+        YRX_INVALID_ARGUMENT = 6,
+        YRX_INVALID_UTF8 = 7,
+        YRX_SERIALIZATION_ERROR = 8,
+        YRX_NO_METADATA = 9,
+    }
+
+    public struct YRX_BUFFER
+    {
+        public IntPtr data;
+        public nuint length;
+    }
+
+
+    public struct YRX_METADATA_BYTES
+    {
+        public int length;
+        public IntPtr data;
+    }
+
+    public enum YRX_METADATA_VALUE_TYPE
+    {
+        YRX_I64,
+        YRX_F64,
+        YRX_BOOLEAN,
+        YRX_STRING,
+        YRX_BYTES,
+    }
+
+    // Magic for union types.
+    [StructLayout(LayoutKind.Explicit)]
+    public struct YRX_METADATA_VALUE
+    {
+        [FieldOffset(0)]
+        public Int64 i64;
+        [FieldOffset(0)]
+        public double f64;
+        [FieldOffset(0)]
+        public bool boolean;
+        [FieldOffset(0)]
+        public IntPtr String;
+        // public char[] String;
+        [FieldOffset(0)]
+        public YRX_METADATA_BYTES bytes;
+    }
+
+    public struct YRX_METADATA
+    {
+        public string identifier;
+        public YRX_METADATA_VALUE_TYPE value_type;
+        public YRX_METADATA_VALUE value;
+    }
+    public static class YaraX
+    {
+        [DllImport("yara_x_capi.dll")]
+        public static extern void yrx_buffer_destroy(IntPtr buffer);
+
+        /*
+         * Compiler Functions
+         */
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_create(int flags, out IntPtr compiler);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern void yrx_compiler_destroy(IntPtr compiler);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern IntPtr yrx_compiler_build(IntPtr compiler);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_add_source(IntPtr compiler, string src);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_errors_json(IntPtr compiler, out IntPtr buf);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_warnings_json(IntPtr compiler, out IntPtr buf);
+
+        /*
+         * Rule Functions
+         */
+        [DllImport("yara_x_capi.dll")]
+        public static extern void yrx_rules_destroy(IntPtr rules);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern int yrx_rules_count(IntPtr rules);
+
+        public delegate void YRX_METADATA_CALLBACK(IntPtr metadata);
+        public delegate void YRX_TAGS_CALLBACK(IntPtr tag);
+        public delegate void YRX_PATTERN_CALLBACK(IntPtr pattern);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern IntPtr yrx_rule_iter_metadata(IntPtr rule, YRX_METADATA_CALLBACK callback);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern IntPtr yrx_rule_iter_tags(IntPtr rule, YRX_TAGS_CALLBACK callback);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern IntPtr yrx_rule_iter_patterns(IntPtr rule, YRX_PATTERN_CALLBACK callback);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_pattern_identifier(IntPtr pattern, out IntPtr identifier, out int length);
+
+        /*
+         * Scanner Functions
+         */
+        public delegate void YRX_RULE_CALLBACK(IntPtr rule);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_create(IntPtr rules, out IntPtr scanner);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern void yrx_scanner_destroy(IntPtr scanner);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_scan(IntPtr scanner, byte[] data, long len);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_on_matching_rule(IntPtr scanner, YRX_RULE_CALLBACK callback);
+    }
+}

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -110,6 +110,9 @@ namespace YaraXSharp
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_compiler_ban_module(IntPtr compiler, string module, string error_title, string error_msg);
 
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_new_namespace(IntPtr compiler, string name);
+
         /*
          * Rule Functions
          */

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -134,9 +134,13 @@ namespace YaraXSharp
         [DllImport("yara_x_capi.dll")]
         public static extern int yrx_rules_count(IntPtr rules);
 
+        public delegate void YRX_RULE_CALLBACK(IntPtr rule);
         public delegate void YRX_METADATA_CALLBACK(IntPtr metadata);
         public delegate void YRX_TAGS_CALLBACK(IntPtr tag);
         public delegate void YRX_PATTERN_CALLBACK(IntPtr pattern);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_rules_iter(IntPtr rules, YRX_RULE_CALLBACK callback);
 
         [DllImport("yara_x_capi.dll")]
         public static extern IntPtr yrx_rule_iter_metadata(IntPtr rule, YRX_METADATA_CALLBACK callback);
@@ -165,8 +169,6 @@ namespace YaraXSharp
         /*
          * Scanner Functions
          */
-        public delegate void YRX_RULE_CALLBACK(IntPtr rule);
-
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_scanner_set_timeout(IntPtr scanner, long timeout);
 

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -127,6 +127,12 @@ namespace YaraXSharp
         public static extern YRX_RESULT yrx_pattern_identifier(IntPtr pattern, out IntPtr identifier, out int length);
 
         [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_rule_identifier(IntPtr rule, out IntPtr identifier, out int length);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_rule_namespace(IntPtr rule, out IntPtr identifier, out int length);
+
+        [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_rules_serialize(IntPtr rules, out IntPtr buf);
 
         [DllImport("yara_x_capi.dll")]

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -104,6 +104,12 @@ namespace YaraXSharp
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_compiler_warnings_json(IntPtr compiler, out IntPtr buf);
 
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_ignore_module(IntPtr compiler, string module);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_ban_module(IntPtr compiler, string module, string error_title, string error_msg);
+
         /*
          * Rule Functions
          */

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -181,5 +181,16 @@ namespace YaraXSharp
 
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_scanner_on_matching_rule(IntPtr scanner, YRX_RULE_CALLBACK callback);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_set_global_str(IntPtr compiler, string identifier, string value);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_set_global_bool(IntPtr compiler, string identifier, bool value);
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_set_global_int(IntPtr compiler, string identifier, int value);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_set_global_float(IntPtr compiler, string identifier, double value);
     }
 }

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -135,12 +135,16 @@ namespace YaraXSharp
         public static extern int yrx_rules_count(IntPtr rules);
 
         public delegate void YRX_RULE_CALLBACK(IntPtr rule);
+        public delegate void YRX_IMPORTS_CALLBACK(string module_name);
         public delegate void YRX_METADATA_CALLBACK(IntPtr metadata);
         public delegate void YRX_TAGS_CALLBACK(IntPtr tag);
         public delegate void YRX_PATTERN_CALLBACK(IntPtr pattern);
 
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_rules_iter(IntPtr rules, YRX_RULE_CALLBACK callback);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_rules_iter_imports(IntPtr rules, YRX_IMPORTS_CALLBACK callback);
 
         [DllImport("yara_x_capi.dll")]
         public static extern IntPtr yrx_rule_iter_metadata(IntPtr rule, YRX_METADATA_CALLBACK callback);

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -126,6 +126,12 @@ namespace YaraXSharp
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_pattern_identifier(IntPtr pattern, out IntPtr identifier, out int length);
 
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_rules_serialize(IntPtr rules, out IntPtr buf);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_rules_deserialize(byte[] data, long len, out IntPtr rules);
+
         /*
          * Scanner Functions
          */

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -96,6 +96,9 @@ namespace YaraXSharp
         public static extern YRX_RESULT yrx_compiler_add_source(IntPtr compiler, string src);
 
         [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_add_source_with_origin(IntPtr compiler, string src, string origin);
+
+        [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_compiler_errors_json(IntPtr compiler, out IntPtr buf);
 
         [DllImport("yara_x_capi.dll")]

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -113,6 +113,18 @@ namespace YaraXSharp
         [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_compiler_new_namespace(IntPtr compiler, string name);
 
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_define_global_str(IntPtr compiler, string identifier, string value);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_define_global_bool(IntPtr compiler, string identifier, bool value);
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_define_global_int(IntPtr compiler, string identifier, int value);
+
+        [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_compiler_define_global_float(IntPtr compiler, string identifier, double value);
+
+
         /*
          * Rule Functions
          */

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -138,6 +138,9 @@ namespace YaraXSharp
         public delegate void YRX_RULE_CALLBACK(IntPtr rule);
 
         [DllImport("yara_x_capi.dll")]
+        public static extern YRX_RESULT yrx_scanner_set_timeout(IntPtr scanner, long timeout);
+
+        [DllImport("yara_x_capi.dll")]
         public static extern YRX_RESULT yrx_scanner_create(IntPtr rules, out IntPtr scanner);
 
         [DllImport("yara_x_capi.dll")]

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>Yara-X Sharp</Title>
     <Authors>jtPox</Authors>
@@ -14,7 +14,7 @@
     <PackageProjectUrl>https://github.com/jtpox/Yara-X-Sharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/jtpox/Yara-X-Sharp</RepositoryUrl>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
-    <Version>0.1.0</Version>
+    <Version>1.0.0</Version>
     <PackageOutputPath>$(OutputPath)</PackageOutputPath>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>

--- a/readme.md
+++ b/readme.md
@@ -11,17 +11,17 @@ For versions 0.0.3 and below, bring your own `yara_x_capi.dll` which you can fin
 /*
  * New Compiler instance.
  * You can pass multiple params from YRX_COMPILE_FLAGS.
- * E.g. new YaraX(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN)
+ * E.g. new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN)
  */
-var yara = new YaraX();
+var yara = new Compiler();
 yara.AddRuleFile("./eicar.yar");
 var (rules, errors, warnings) = yara.Build(); // Compiled rules to be used in Scanner.
 
 Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS);
 scanner.scan("./eicar.txt");
-List<Rule> results = scanner.Results();
+List<Match> results = scanner.Results();
 
-foreach (Rule rule in results) {
+foreach (Match rule in results) {
   Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
   Console.WriteLine(rule.Metadata["malware_family"]);
 }
@@ -34,21 +34,21 @@ yara.Destroy();
 Or 
 
 ```csharp
-using (var yara = new YaraX())
+using (var yara = new Compiler())
 {
   yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eicar.yar"));
   yara.AddRuleFile(Path.Combine(Environment.CurrentDirectory, "../../../", "eitwo.yar"));
   var (rules, errors, warnings) = yara.Build();
 
-  Console.WriteLine($"Number of rules: {yara.RulesCount()}");
+  Console.WriteLine($"Number of rules: {rules.Count()}");
 
   using (Scanner scanner = new Scanner(rules, YRX_SCANNER_FLAGS.LOAD_METADATA, YRX_SCANNER_FLAGS.LOAD_PATTERNS))
   {
       scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
-      List<Rule> results = scanner.Results();
+      List<Match> results = scanner.Results();
       Console.WriteLine($"Matches: {results.Count}");
 
-      foreach (Rule rule in results)
+      foreach (Match rule in results)
       {
           Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
           Console.WriteLine(rule.Metadata["malware_family"]);


### PR DESCRIPTION
New features and implementations:
1. Moved C/C++ API functions into a separate class
2. Moved Wrapper functions into 4 main classes

# 1. Moved C/C++ API functions into a separate class
If you want to skip using the wrapper entirely and use the C/C++ API, you can access most functions through the `YaraX` class.
Example:
```csharp
IntPtr compiler;
YaraX.yrx_compiler_create(0, out compiler);
YaraX.yrx_compiler_build(compiler);
```

Please do note that some functions from the C/C++ API are not added yet. If they aren't, it means that I have yet to understand what it is going to do and will be added in future updates.

# 2. Moved Wrapper functions into 4 main classes
The wrapper will now consist of 4 main classes: `Compiler`, `Rules`, `Scanner`, and `Match`.

## Compiler
Renamed from `YaraX` as that class is now reserved for the C/C++ API.
#### CHANGE: Compiler.Build()
The return of the function will now return a Tuple of `(Rules, errors, warnings)` instead of `(IntPtr, errors, warnings)`

## Rules
Usable without the `Compiler` class.

If an instance of `Rules` is not instantiated from `Compiler.Build()`, you have to call `Rules.Destroy()` or dispose with a `using()` block.

#### NEW: Rules.Count() -> int
Used to be `Compiler.RuleCount()`, now moved into the `Rules` class, works the same way.

#### NEW: Rules.Export() -> byte[]
Allows you to export compiled Yara-X rules as `byte[]`.

#### NEW: Rules.Import(byte[] buffer)
Allows you to import compiled rules from `byte[]`.
Example:
```csharp
using (Rules rules = new Rules()) {
  rules.Import(File.ReadAllBytes("./ydb.dat"));
}
```

## Scanner
#### NEW: Flags
`YRX_SCANNER_FLAGS.LOAD_NAMESPACE` loads namespace of the matched rule.
`YRX_SCANNER_FLAGS.LOAD_IDENTIFIER` loads the identifier of the matched rule.

#### NEW: Scanner.SetTimeout(int seconds)
Set the scanning timeout in seconds.

## Match
Renamed from `Rule`. Each rule matched will be in a `Match` class.

#### NEW: Match.Namespace
A string that will output the namespace that the rule is in.
`YRX_SCANNER_FLAGS.LOAD_NAMESPACE` has to be used in the `Scanner` class.

#### NEW: Match.Identifier
A string that will output the identifier of the rule.
`YRX_SCANNER_FLAGS.LOAD_IDENTIFIER` has to be used in the `Scanner` class.