### PR TITLE
1.0.3

### DIFF
--- a/YaraXSharp/Compiler.cs
+++ b/YaraXSharp/Compiler.cs
@@ -34,6 +34,13 @@ namespace YaraXSharp
             YaraX.yrx_compiler_add_source_with_origin(_compiler, File.ReadAllText(filePath), filePath);
             // if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
+
+        public void AddIncludeDir(string directory)
+        {
+            var result = YaraX.yrx_compiler_add_include_dir(_compiler, directory);
+            if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
+        }
+
         public Tuple<Rules, YrxErrorFormat[], YrxErrorFormat[]> Build()
         {
             YrxErrorFormat[] errors = _Errors();

--- a/YaraXSharp/Match.cs
+++ b/YaraXSharp/Match.cs
@@ -16,7 +16,7 @@ namespace YaraXSharp
         public List<string> Patterns = new List<string>();
         public string Namespace = null;
         public string Identifier = null;
-        public Match(IntPtr rule, params YRX_SCANNER_FLAGS[] load_info)
+        internal Match(IntPtr rule, params YRX_SCANNER_FLAGS[] load_info)
         {
             _rule = rule;
             if (load_info.Contains(YRX_SCANNER_FLAGS.LOAD_METADATA)) GetMetadata();

--- a/YaraXSharp/Rules.cs
+++ b/YaraXSharp/Rules.cs
@@ -10,9 +10,14 @@ namespace YaraXSharp
     public class Rules : IDisposable
     {
         internal IntPtr _pointer = IntPtr.Zero;
-        public Rules(IntPtr rulesPtr = default)
+        internal Rules(IntPtr rulesPtr)
         {
             _pointer = rulesPtr;
+        }
+
+        public Rules()
+        {
+            _pointer = IntPtr.Zero;
         }
 
         public int Count()

--- a/YaraXSharp/Scanner.cs
+++ b/YaraXSharp/Scanner.cs
@@ -60,6 +60,7 @@ namespace YaraXSharp
         public void Destroy()
         {
             YaraX.yrx_scanner_destroy(_scanner);
+            _scanner = IntPtr.Zero;
         }
 
         public void Dispose()

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -125,6 +125,9 @@ namespace YaraXSharp
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_compiler_define_global_float(IntPtr compiler, string identifier, double value);
 
+        [DllImport("yara_x_capi")]
+        public static extern YRX_RESULT yrx_compiler_add_include_dir(IntPtr compiler, string dir);
+
 
         /*
          * Rule Functions

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -4,17 +4,17 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<AssemblyVersion>1.0.2</AssemblyVersion>
+		<AssemblyVersion>1.0.3</AssemblyVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Yara-X Sharp</Title>
 		<Authors>jtPox</Authors>
-		<Description>A simple wrapper for Yara-X rule scanning on .NET.</Description>
+		<Description>A simple wrapper for Yara-X pattern matching on .NET.</Description>
 		<PackageTags>yara,yara-x,yara-scanner,wrapper-api,wrapper-library,wrapper,csharp,net,yara-forensics,yara-x-capi</PackageTags>
-		<FileVersion>1.0.2</FileVersion>
+		<FileVersion>1.0.3</FileVersion>
 		<PackageProjectUrl>https://github.com/jtpox/Yara-X-Sharp</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/jtpox/Yara-X-Sharp</RepositoryUrl>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<PackageOutputPath>$(OutputPath)</PackageOutputPath>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -32,16 +32,17 @@
 
 	<ItemGroup>
 		<Folder Include="yara_x_capi\1.4.0\" />
+		<Folder Include="yara_x_capi\1.5.0\" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Content Include="yara_x_capi\1.4.0\yara_x_capi.dll">
+		<Content Include="yara_x_capi\1.5.0\yara_x_capi.dll">
 			<!-- Windows x64 CAPI -->
 			<Pack>True</Pack>
 			<!-- <PackagePath>lib\$(TargetFramework)</PackagePath> -->
 			<PackagePath>runtimes\win-x64\native</PackagePath>
 		</Content>
-		<Content Include="yara_x_capi\1.4.0\libyara_x_capi.so">
+		<Content Include="yara_x_capi\1.5.0\libyara_x_capi.so">
 			<!-- Linux x64 CAPI -->
 			<Pack>True</Pack>
 			<PackagePath>runtimes\linux-x64\native</PackagePath>
@@ -49,12 +50,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="yara_x_capi\1.4.0\yara_x_capi.dll">
+		<None Update="yara_x_capi\1.5.0\yara_x_capi.dll">
 			<!-- Windows x64 CAPI -->
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>
 		</None>
-		<None Update="yara_x_capi\1.4.0\libyara_x_capi.so">
+		<None Update="yara_x_capi\1.5.0\libyara_x_capi.so">
 			<!-- Linux x64 CAPI -->
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>

--- a/readme.md
+++ b/readme.md
@@ -73,4 +73,5 @@ using (var yara = new Compiler())
 | Yara-X Release Version | Wrapper Version |
 |--|--|
 | [1.4.0](https://github.com/VirusTotal/yara-x/releases/tag/v1.4.0) | 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.1.0, [1.0.0](https://github.com/jtpox/Yara-X-Sharp/pull/4) |
+| [1.5.0](https://github.com/VirusTotal/yara-x/releases/tag/v1.5.0) | 1.0.x
 

--- a/readme.md
+++ b/readme.md
@@ -62,16 +62,9 @@ using (var yara = new Compiler())
 ## Reference
 - [Yara-X C/C++ API Documentation](https://virustotal.github.io/yara-x/docs/api/c/c-/)
 
-## To-Dos
-- ~~Compiler flags~~
-- ~~Compiler error and warnings~~
-- ~~Scanner timeout~~
-- ~~Iterate matched rule patterns and tags~~
-- ~~File streaming for scanning large files~~ [BYO](https://github.com/jtpox/Yara-X-Sharp/commit/596f3b0e6da6989e2936eb0bff213742737865be)
-
 ## Compatibility
 | Yara-X Release Version | Wrapper Version |
 |--|--|
 | [1.4.0](https://github.com/VirusTotal/yara-x/releases/tag/v1.4.0) | 0.0.1, 0.0.2, 0.0.3, 0.0.4, 0.0.5, 0.1.0, [1.0.0](https://github.com/jtpox/Yara-X-Sharp/pull/4) |
-| [1.5.0](https://github.com/VirusTotal/yara-x/releases/tag/v1.5.0) | 1.0.x
+| [1.5.0](https://github.com/VirusTotal/yara-x/releases/tag/v1.5.0) | 1.0.3
 


### PR DESCRIPTION
# New Features
- Compatible with Yara-X 1.5.0
- Add `yrx_compiler_add_include_dir` interop

# Changes
- `Match` class can now only be instantiated internally.
- `Rules` class no longer needs `IntPtr` parameter when instantiated externally.