### PR TITLE
Feat: Slow rules and Clear Profile in `Scanner`

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -17,6 +17,7 @@ namespace TestApp
 
                     yara.AddRuleFile("./eicar.yar");
                     yara.AddRuleFile("./eitwo.yar");
+                    yara.AddRuleFile("./slowrule.yar");
                     var (rules, errors, warnings) = yara.Build();
 
                     if (errors.Length != 0) _LoopErrorFormat(errors);

--- a/TestApp/TestApp.csproj
+++ b/TestApp/TestApp.csproj
@@ -18,6 +18,9 @@
     <None Update="eitwo.yar">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="slowrule.yar">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/TestApp/slowrule.yar
+++ b/TestApp/slowrule.yar
@@ -1,0 +1,19 @@
+﻿rule VerySlowExample
+{
+    meta:
+        malware_family = "Slow Test"
+
+    strings:
+        // Unanchored regex with lots of backtracking potential
+        $re1 = /[A-Za-z0-9]{5,1000}/
+        
+        // Wildcard-heavy hex pattern
+        $hex1 = { 6A ?? ?? ?? ?? 68 ?? ?? ?? ?? ?? ?? 6A ?? }
+        
+        // Large string with wide/ascii modifiers
+        $s1 = "This is a very long string that might appear in multiple encodings across the file" wide ascii
+
+    condition:
+        // Scans for any of these across the entire file
+        any of them
+}

--- a/YaraXSharp/Declaratives.cs
+++ b/YaraXSharp/Declaratives.cs
@@ -16,6 +16,14 @@ namespace YaraXSharp
         LOAD_IDENTIFIER,
     }
 
+    public class SlowestRules
+    {
+        public string Namespace;
+        public string Rule;
+        public double MatchTime;
+        public double EvalTime;
+    }
+
     public class YrxException : Exception
     {
         public YrxException(string message) : base(message) { }

--- a/YaraXSharp/Scanner.cs
+++ b/YaraXSharp/Scanner.cs
@@ -75,6 +75,12 @@ namespace YaraXSharp
             return _matchedRules;
         }
 
+        public void ClearProfilingData()
+        {
+            YRX_RESULT result = YaraX.yrx_scanner_clear_profiling_data(_scanner);
+            if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
+        }
+
         public void Destroy()
         {
             YaraX.yrx_scanner_destroy(_scanner);

--- a/YaraXSharp/Scanner.cs
+++ b/YaraXSharp/Scanner.cs
@@ -30,6 +30,24 @@ namespace YaraXSharp
             if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
 
+        public List<SlowestRules> GetSlowestRules(uint maxResults)
+        {
+            List<SlowestRules> slowestRules = new List<SlowestRules>();
+            YRX_RESULT result = YaraX.yrx_scanner_iter_slowest_rules(_scanner, maxResults, (string nameSpace, string ruleName, double matchTime, double evalTime) =>
+            {
+                slowestRules.Add(new SlowestRules
+                {
+                    Namespace = nameSpace,
+                    Rule = ruleName,
+                    MatchTime = matchTime,
+                    EvalTime = evalTime,
+                });
+            });
+
+            if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
+            return slowestRules;
+        }
+
         public void Scan(string filePath)
         {
             if (!File.Exists(filePath)) throw new YrxException("File does not exist.");

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -177,6 +177,8 @@ namespace YaraXSharp
         /*
          * Scanner Functions
          */
+        public delegate void YRX_SLOWEST_RULES_CALLBACK(string nameSpace, string ruleName, double matchTime, double evalTime);
+
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_set_timeout(IntPtr scanner, long timeout);
 
@@ -191,6 +193,9 @@ namespace YaraXSharp
 
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_on_matching_rule(IntPtr scanner, YRX_RULE_CALLBACK callback);
+
+        [DllImport("yara_x_capi")]
+        public static extern YRX_RESULT yrx_scanner_iter_slowest_rules(IntPtr scanner, uint maxResults, YRX_SLOWEST_RULES_CALLBACK callback);
 
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_set_global_str(IntPtr compiler, string identifier, string value);

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -19,15 +19,16 @@ namespace YaraXSharp
 
     public enum YRX_RESULT
     {
-        YRX_SUCCESS = 0,
-        YRX_SYNTAX_ERROR = 1,
-        YRX_VARIABLE_ERROR = 3,
-        YRX_SCAN_ERROR = 4,
-        YRX_SCAN_TIMEOUT = 5,
-        YRX_INVALID_ARGUMENT = 6,
-        YRX_INVALID_UTF8 = 7,
-        YRX_SERIALIZATION_ERROR = 8,
-        YRX_NO_METADATA = 9,
+        YRX_SUCCESS,
+        YRX_SYNTAX_ERROR,
+        YRX_VARIABLE_ERROR,
+        YRX_SCAN_ERROR,
+        YRX_SCAN_TIMEOUT,
+        YRX_INVALID_ARGUMENT,
+        YRX_INVALID_UTF8,
+        YRX_SERIALIZATION_ERROR,
+        YRX_NO_METADATA,
+        YRX_NOT_SUPPORTED,
     }
 
     public struct YRX_BUFFER
@@ -207,5 +208,8 @@ namespace YaraXSharp
 
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_set_global_float(IntPtr compiler, string identifier, double value);
+
+        [DllImport("yara_x_capi")]
+        public static extern YRX_RESULT yrx_scanner_clear_profiling_data(IntPtr scanner);
     }
 }


### PR DESCRIPTION
# New Features
1. Iterate through slowest rules in `Scanner`
2. Clear profiling in `Scanner`

Note: These features require you to compile your own CAPI with `rules-profiling` enabled. Otherwise both functions will throw a `YrxException` with `YRX_NOT_SUPPORTED`.

# Fix
1. `YRX_RESULT` error codes