### PR TITLE
Feature: Block Scanning

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -88,7 +88,7 @@ namespace TestApp
                     ))
                     {
                         scanner.SetTimeout(3);
-                        scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
+                        scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"), 8);
                         List<Match> results = scanner.Results();
                         Console.WriteLine($"Matches: {results.Count}");
 

--- a/TestApp/eitwo.yar
+++ b/TestApp/eitwo.yar
@@ -14,8 +14,8 @@
 
 	strings:
 
-		$s1 = "X5O!P%@AP[4\\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*" fullword ascii
+		$s1 = "STANDA" fullword ascii
 
 	condition:
-		console.log("eicar2") and any of them
+		any of them
 }

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -221,9 +221,9 @@ namespace YaraXSharp
         public static extern YRX_RESULT yrx_scanner_set_module_data(IntPtr scanner, string name, byte data, uint length);
 
         [DllImport("yara_x_capi")]
-        public static extern YRX_RESULT yrx_scanner_scan_block(IntPtr scanner, uint base, byte data, uint len);
+        public static extern YRX_RESULT yrx_scanner_scan_block(IntPtr scanner, uint block_number, byte[] data, uint len);
 
         [DllImport("yara_x_capi")]
-        public static extern YRX_RESULT yrx_scanner_finish(IntPtr scanner)
+        public static extern YRX_RESULT yrx_scanner_finish(IntPtr scanner);
     }
 }

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -26,6 +26,7 @@ namespace YaraXSharp
         YRX_SCAN_TIMEOUT,
         YRX_INVALID_ARGUMENT,
         YRX_INVALID_UTF8,
+        YRX_INVALID_STATE,
         YRX_SERIALIZATION_ERROR,
         YRX_NO_METADATA,
         YRX_NOT_SUPPORTED,
@@ -209,7 +210,7 @@ namespace YaraXSharp
 
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_set_global_float(IntPtr compiler, string identifier, double value);
-
+        
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_clear_profiling_data(IntPtr scanner);
 
@@ -218,5 +219,11 @@ namespace YaraXSharp
 
         [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_set_module_data(IntPtr scanner, string name, byte data, uint length);
+
+        [DllImport("yara_x_capi")]
+        public static extern YRX_RESULT yrx_scanner_scan_block(IntPtr scanner, uint base, byte data, uint len);
+
+        [DllImport("yara_x_capi")]
+        public static extern YRX_RESULT yrx_scanner_finish(IntPtr scanner)
     }
 }

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -35,16 +35,17 @@
 		<Folder Include="yara_x_capi\1.5.0\" />
 		<Folder Include="yara_x_capi\1.6.0\" />
 		<Folder Include="yara_x_capi\1.7.0\" />
+		<Folder Include="yara_x_capi\1.8.1\" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Content Include="yara_x_capi\1.7.0\yara_x_capi.dll">
+		<Content Include="yara_x_capi\1.8.1\yara_x_capi.dll">
 			<!-- Windows x64 CAPI -->
 			<Pack>True</Pack>
 			<!-- <PackagePath>lib\$(TargetFramework)</PackagePath> -->
 			<PackagePath>runtimes\win-x64\native</PackagePath>
 		</Content>
-		<Content Include="yara_x_capi\1.7.0\libyara_x_capi.so">
+		<Content Include="yara_x_capi\1.8.1\libyara_x_capi.so">
 			<!-- Linux x64 CAPI -->
 			<Pack>True</Pack>
 			<PackagePath>runtimes\linux-x64\native</PackagePath>
@@ -52,12 +53,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="yara_x_capi\1.7.0\yara_x_capi.dll">
+		<None Update="yara_x_capi\1.8.1\yara_x_capi.dll">
 			<!-- Windows x64 CAPI -->
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>
 		</None>
-		<None Update="yara_x_capi\1.7.0\libyara_x_capi.so">
+		<None Update="yara_x_capi\1.8.1\libyara_x_capi.so">
 			<!-- Linux x64 CAPI -->
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>


### PR DESCRIPTION
# New
Introduced in [Yara-X v1.8.0](https://github.com/VirusTotal/yara-x/releases/tag/v1.8.0), block scanning is introduced. Though limited, I have decided to add it into the wrapper.

## `Scanner.Scan(string filePath, int blockSize)`
Using file streaming for incremental scanning.
`blockSize` - chunk size to scan


# Reference
 https://github.com/VirusTotal/yara-x/commit/185c2ee4d4a81d76a53432911dd8c9d1c492b314#diff-f47069bf9d8dd922e07a8f0b06069f9c023c485acda67af6b4c5aa1a1a8f5146
