### PR TITLE
Update: Yara-X 1.9.0

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -7,101 +7,9 @@ namespace TestApp
         {
             try
             {
-
-                Console.WriteLine("Test 1");
-                using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
-                {
-                    yara.IgnoreModule("console");
-                    yara.BanModule("console", "Console", "Console is banned");
-                    yara.DefineGlobal("foo", "bar");
-
-                    yara.AddRuleFile("./eicar.yar");
-                    yara.AddRuleFile("./eitwo.yar");
-                    yara.AddRuleFile("./slowrule.yar");
-                    var (rules, errors, warnings) = yara.Build();
-
-                    if (errors.Length != 0) _LoopErrorFormat(errors);
-                    if (warnings.Length != 0) _LoopErrorFormat(warnings);
-
-                    Console.WriteLine($"Number of rules: {rules.Count()}");
-
-                    using (Scanner scanner = new Scanner(
-                        rules,
-                        YRX_SCANNER_FLAGS.LOAD_METADATA,
-                        YRX_SCANNER_FLAGS.LOAD_PATTERNS,
-                        YRX_SCANNER_FLAGS.LOAD_NAMESPACE,
-                        YRX_SCANNER_FLAGS.LOAD_IDENTIFIER
-                    ))
-                    {
-                        scanner.SetTimeout(3);
-                        scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
-                        List<Match> results = scanner.Results();
-                        Console.WriteLine($"Matches: {results.Count}");
-
-                        foreach (Match rule in results)
-                        {
-                            Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
-                            Console.WriteLine($"Family: {rule.Metadata["malware_family"]}");
-                            Console.WriteLine($"Namespace: {rule.Namespace}");
-                            Console.WriteLine($"Identifier: {rule.Identifier}");
-                            Console.WriteLine("-");
-                        }
-                    }
-                }
-
-                Console.WriteLine("---");
-
-                Console.WriteLine("Test 2");
-                if (File.Exists("./ydb.dat")) File.Delete("./ydb.dat");
-                using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
-                {
-                    yara.AddRuleFile("./eicar.yar");
-                    yara.AddRuleFile("./eitwo.yar");
-                    var (rules, errors, warnings) = yara.Build();
-
-                    if (errors.Length != 0) _LoopErrorFormat(errors);
-                    if (warnings.Length != 0) _LoopErrorFormat(warnings);
-
-                    var export = rules.Export();
-                    using (var fs = new FileStream("./ydb.dat", FileMode.Create, FileAccess.Write))
-                    {
-                        fs.Write(export, 0, export.Length);
-                        Console.WriteLine("Serialized rules exported to ydb.dat");
-                    }
-                }
-
-                Console.WriteLine("---");
-
-                Console.WriteLine("Test 3");
-                using (Rules rules = new Rules())
-                {
-                    var serializedRules = File.ReadAllBytes("./ydb.dat");
-                    rules.Import(serializedRules);
-                    Console.WriteLine($"Number of rules: {rules.Count()}");
-
-                    using (Scanner scanner = new Scanner(
-                        rules,
-                        YRX_SCANNER_FLAGS.LOAD_METADATA,
-                        YRX_SCANNER_FLAGS.LOAD_PATTERNS,
-                        YRX_SCANNER_FLAGS.LOAD_NAMESPACE,
-                        YRX_SCANNER_FLAGS.LOAD_IDENTIFIER
-                    ))
-                    {
-                        scanner.SetTimeout(3);
-                        scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"), 8);
-                        List<Match> results = scanner.Results();
-                        Console.WriteLine($"Matches: {results.Count}");
-
-                        foreach (Match rule in results)
-                        {
-                            Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
-                            Console.WriteLine($"Family: {rule.Metadata["malware_family"]}");
-                            Console.WriteLine($"Namespace: {rule.Namespace}");
-                            Console.WriteLine($"Identifier: {rule.Identifier}");
-                            Console.WriteLine("-");
-                        }
-                    }
-                }
+                TestOne();
+                TestTwo();
+                TestThree();
             } catch (YrxException ex) {
                 Console.Write(ex.Message);
             }
@@ -112,6 +20,110 @@ namespace TestApp
             foreach (var error in errors)
             {
                 Console.WriteLine(error.text);
+            }
+        }
+
+        private static void TestOne()
+        {
+            Console.WriteLine("Test 1");
+            using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
+            {
+                yara.IgnoreModule("console");
+                yara.BanModule("console", "Console", "Console is banned");
+                yara.DefineGlobal("foo", "bar");
+
+                yara.AddRuleFile("./eicar.yar");
+                yara.AddRuleFile("./eitwo.yar");
+                yara.AddRuleFile("./slowrule.yar");
+                var (rules, errors, warnings) = yara.Build();
+
+                if (errors.Length != 0) _LoopErrorFormat(errors);
+                if (warnings.Length != 0) _LoopErrorFormat(warnings);
+
+                Console.WriteLine($"Number of rules: {rules.Count()}");
+
+                using (Scanner scanner = new Scanner(
+                    rules,
+                    YRX_SCANNER_FLAGS.LOAD_METADATA,
+                    YRX_SCANNER_FLAGS.LOAD_PATTERNS,
+                    YRX_SCANNER_FLAGS.LOAD_NAMESPACE,
+                    YRX_SCANNER_FLAGS.LOAD_IDENTIFIER
+                ))
+                {
+                    scanner.SetTimeout(3);
+                    scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"));
+                    List<Match> results = scanner.Results();
+                    Console.WriteLine($"Matches: {results.Count}");
+
+                    foreach (Match rule in results)
+                    {
+                        Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
+                        Console.WriteLine($"Family: {rule.Metadata["malware_family"]}");
+                        Console.WriteLine($"Namespace: {rule.Namespace}");
+                        Console.WriteLine($"Identifier: {rule.Identifier}");
+                        Console.WriteLine("-");
+                    }
+                }
+            }
+
+            Console.WriteLine("---");
+        }
+
+        private static void TestTwo()
+        {
+            Console.WriteLine("Test 2");
+            if (File.Exists("./ydb.dat")) File.Delete("./ydb.dat");
+            using (Compiler yara = new Compiler(YRX_COMPILE_FLAGS.YRX_ERROR_ON_SLOW_PATTERN, YRX_COMPILE_FLAGS.YRX_DISABLE_INCLUDES))
+            {
+                yara.AddRuleFile("./eicar.yar");
+                yara.AddRuleFile("./eitwo.yar");
+                var (rules, errors, warnings) = yara.Build();
+
+                if (errors.Length != 0) _LoopErrorFormat(errors);
+                if (warnings.Length != 0) _LoopErrorFormat(warnings);
+
+                var export = rules.Export();
+                using (var fs = new FileStream("./ydb.dat", FileMode.Create, FileAccess.Write))
+                {
+                    fs.Write(export, 0, export.Length);
+                    Console.WriteLine("Serialized rules exported to ydb.dat");
+                }
+            }
+
+            Console.WriteLine("---");
+        }
+        
+        private static void TestThree()
+        {
+            Console.WriteLine("Test 3");
+            using (Rules rules = new Rules())
+            {
+                var serializedRules = File.ReadAllBytes("./ydb.dat");
+                rules.Import(serializedRules);
+                Console.WriteLine($"Number of rules: {rules.Count()}");
+
+                using (Scanner scanner = new Scanner(
+                    rules,
+                    YRX_SCANNER_FLAGS.LOAD_METADATA,
+                    YRX_SCANNER_FLAGS.LOAD_PATTERNS,
+                    YRX_SCANNER_FLAGS.LOAD_NAMESPACE,
+                    YRX_SCANNER_FLAGS.LOAD_IDENTIFIER
+                ))
+                {
+                    scanner.SetTimeout(3);
+                    scanner.Scan(Path.Combine(Environment.CurrentDirectory, "eicar.txt"), 8);
+                    List<Match> results = scanner.Results();
+                    Console.WriteLine($"Matches: {results.Count}");
+
+                    foreach (Match rule in results)
+                    {
+                        Console.WriteLine($"Pattern match count: {rule.Patterns.Count}");
+                        Console.WriteLine($"Family: {rule.Metadata["malware_family"]}");
+                        Console.WriteLine($"Namespace: {rule.Namespace}");
+                        Console.WriteLine($"Identifier: {rule.Identifier}");
+                        Console.WriteLine("-");
+                    }
+                }
             }
         }
     }

--- a/YaraXSharp/Scanner.cs
+++ b/YaraXSharp/Scanner.cs
@@ -51,8 +51,7 @@ namespace YaraXSharp
         public void Scan(string filePath)
         {
             if (!File.Exists(filePath)) throw new YrxException("File does not exist.");
-            byte[] file = File.ReadAllBytes(filePath);
-            var result = YaraX.yrx_scanner_scan(_scanner, file, file.Length);
+            YRX_RESULT result = result = YaraX.yrx_scanner_scan_file(_scanner, filePath);
             if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
 
@@ -60,7 +59,7 @@ namespace YaraXSharp
         public void Scan(byte[] fileBuffer)
         {
             if (fileBuffer.Length == 0) throw new YrxException("File buffer length is zero.");
-            var result = YaraX.yrx_scanner_scan(_scanner, fileBuffer, fileBuffer.Length);
+            YRX_RESULT result = YaraX.yrx_scanner_scan(_scanner, fileBuffer, fileBuffer.Length);
             if (result != YRX_RESULT.YRX_SUCCESS) throw new YrxException(result.ToString());
         }
 

--- a/YaraXSharp/YaraX.cs
+++ b/YaraXSharp/YaraX.cs
@@ -194,6 +194,9 @@ namespace YaraXSharp
         public static extern YRX_RESULT yrx_scanner_scan(IntPtr scanner, byte[] data, long len);
 
         [DllImport("yara_x_capi")]
+        public static extern YRX_RESULT yrx_scanner_scan_file(IntPtr scanner, string path);
+
+        [DllImport("yara_x_capi")]
         public static extern YRX_RESULT yrx_scanner_on_matching_rule(IntPtr scanner, YRX_RULE_CALLBACK callback);
 
         [DllImport("yara_x_capi")]

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -36,16 +36,17 @@
 		<Folder Include="yara_x_capi\1.6.0\" />
 		<Folder Include="yara_x_capi\1.7.0\" />
 		<Folder Include="yara_x_capi\1.8.1\" />
+		<Folder Include="yara_x_capi\1.9.0\" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Content Include="yara_x_capi\1.8.1\yara_x_capi.dll">
+		<Content Include="yara_x_capi\1.9.0\yara_x_capi.dll">
 			<!-- Windows x64 CAPI -->
 			<Pack>True</Pack>
 			<!-- <PackagePath>lib\$(TargetFramework)</PackagePath> -->
 			<PackagePath>runtimes\win-x64\native</PackagePath>
 		</Content>
-		<Content Include="yara_x_capi\1.8.1\libyara_x_capi.so">
+		<Content Include="yara_x_capi\1.9.0\libyara_x_capi.so">
 			<!-- Linux x64 CAPI -->
 			<Pack>True</Pack>
 			<PackagePath>runtimes\linux-x64\native</PackagePath>
@@ -53,12 +54,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<None Update="yara_x_capi\1.8.1\yara_x_capi.dll">
+		<None Update="yara_x_capi\1.9.0\yara_x_capi.dll">
 			<!-- Windows x64 CAPI -->
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>
 		</None>
-		<None Update="yara_x_capi\1.8.1\libyara_x_capi.so">
+		<None Update="yara_x_capi\1.9.0\libyara_x_capi.so">
 			<!-- Linux x64 CAPI -->
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 			<TargetPath>%(Filename)%(Extension)</TargetPath>

--- a/YaraXSharp/YaraXSharp.csproj
+++ b/YaraXSharp/YaraXSharp.csproj
@@ -4,17 +4,17 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<AssemblyVersion>1.1.0.181</AssemblyVersion>
+		<AssemblyVersion>1.1.1.190</AssemblyVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>Yara-X Sharp</Title>
 		<Authors>jtPox</Authors>
 		<Description>A simple wrapper for Yara-X pattern matching on .NET.</Description>
 		<PackageTags>yara,yara-x,yara-scanner,wrapper-api,wrapper-library,wrapper,csharp,net,yara-forensics,yara-x-capi</PackageTags>
-		<FileVersion>1.1.0.181</FileVersion>
+		<FileVersion>1.1.1.190</FileVersion>
 		<PackageProjectUrl>https://github.com/jtpox/Yara-X-Sharp</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/jtpox/Yara-X-Sharp</RepositoryUrl>
 		<PackageReadmeFile>readme.md</PackageReadmeFile>
-		<Version>1.1.0.181</Version>
+		<Version>1.1.1.190</Version>
 		<PackageOutputPath>$(OutputPath)</PackageOutputPath>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>


### PR DESCRIPTION
# New
- Interop for `yrx_scanner_scan_file`

# Update
- `Scanner.Scan(string filePath)` now uses `yrx_scanner_scan_file` instead of retrieving binary data and passing it to `yrx_scanner_scan`